### PR TITLE
Revision 0.9.7

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,9 +69,11 @@ License: MIT
   - [Tuple](#Tuple)
   - [Union](#Union)
   - [Array](#Array)
-  - [Until](#Until)
   - [Optional](#Optional)
   - [Epsilon](#Epsilon)
+- [Range](#Range)
+  - [Until](#Until)
+  - [UntilNonEmpty](#UntilNonEmpty)
 - [Terminals](#Terminals)
   - [Number](#Number)
   - [String](#String)
@@ -187,27 +189,6 @@ const R2 = Runtime.Parse(T, 'X X X Y Z')             // const R2 = [['X', 'X', '
 const R3 = Runtime.Parse(T, 'Y Z')                   // const R3 = [[], 'Y Z']
 ```
 
-### Until
-
-The Until combinator will parse characters up to (but not including) one of the specified sentinel string values. If a sentinel value is not found, parsing fails.
-
-**BNF**
-
-```bnf
-<T> ::= ? any character until ['Z'] ?
-```
-
-**TypeScript**
-
-```typescript
-const T = Runtime.Until(['Z'])                      // const T = {
-                                                    //   type: 'Until',
-                                                    //   values: ['Z']
-                                                    // }
-
-const R = Runtime.Parse(T, 'X Y Z')                 // const R = ['X Y ', 'Z']
-```
-
 ### Optional
 
 The Optional combinator parses zero or one occurrence of the interior parser, returning a tuple with one element or an empty tuple if there is no match.
@@ -256,7 +237,58 @@ const R1 = Runtime.Parse(T, 'X Y Z')                // const R1 = [['X', 'Y'], '
 const R2 = Runtime.Parse(T, 'Y Z')                  // const R2 = [[], 'Y Z']
 ```
 
-## Terminals
+## Range Combinators
+
+ParseBox range combinators match character sequences up to one or more terminating sentinel strings. These combinators are used to match arbituary Unicode (UTF-16) sequences.
+
+
+### Until
+
+The Until combinator parses characters up to (but not including) one of the specified sentinel string values. It captures all characters encountered before the sentinel. If a sentinel value is not found in the input, parsing fails. Until succeeds even if it matches a zero-length string. This occurs if a sentinel is found immediately at the current parsing position.
+
+**BNF**
+
+```bnf
+<T> ::= ? any character sequence (0 or more) until 'Z' ?
+```
+
+**TypeScript**
+
+```typescript
+const T = Runtime.Until(['Z'])                      // const T = {
+                                                    //   type: 'Until',
+                                                    //   values: ['Z']
+                                                    // }
+
+const R = Runtime.Parse(T, 'X Y Z')                 // const R = ['X Y ', 'Z']
+```
+
+### UntilNonEmpty
+
+The UntilNonEmpty combinator works the same as Until, but it fails if the parsed content yields a zero-length string.
+
+**BNF**
+
+```bnf
+<T> ::= ? any character sequence (1 or more) until 'Z'. fails on zero length ?
+```
+
+**TypeScript**
+
+```typescript
+const T = Runtime.UntilNonEmpty(['Z'])              // const T = {
+                                                    //   type: 'UntilNonEmpty',
+                                                    //   values: ['Z']
+                                                    // }
+
+const R1 = Runtime.Parse(T, 'X Y Z')                // const R1 = ['X Y ', 'Z']
+
+const R2 = Runtime.Parse(T, ' Z')                   // const R2 = [' ', 'Z']
+
+const R3 = Runtime.Parse(T, 'Z')                    // const R3 = []
+```
+
+## Terminal Combinators
 
 ParseBox provides combinators for parsing common lexical tokens, such as numbers, identifiers, and strings, enabling static, optimized parsing of typical JavaScript constructs.
 

--- a/src/compile/common/comment.ts
+++ b/src/compile/common/comment.ts
@@ -27,23 +27,26 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 // deno-fmt-ignore-file
-// deno-lint-ignore-file no-unused-vars
+// deno-lint-ignore-file
 
 import { Runtime } from '../../runtime/index.ts'
 import { Unreachable } from './unreachable.ts'
 import { Escape } from './escape.ts'
 
+function FromArray(parser: Runtime.IArray): string {
+  return `${FromParser(parser.parser)}[]`
+}
 function FromContext(parser: Runtime.IContext): string {
   return `${FromParser(parser.left)} -> ${FromParser(parser.right)}`
 }
-function FromTuple(parser: Runtime.ITuple): string {
-  return `[${parser.parsers.map((parser) => `${FromParser(parser)}`).join(', ')}]`
+function FromConst(parser: Runtime.IConst): string {
+  return `'${Escape(parser.value)}'`
 }
-function FromUnion(parser: Runtime.IUnion): string {
-  return parser.parsers.map((parser) => `${FromParser(parser)}`).join(' | ')
+function FromIdent(parser: Runtime.IIdent): string {
+  return `<Ident>`
 }
-function FromArray(parser: Runtime.IArray): string {
-  return `${FromParser(parser.parser)}[]`
+function FromNumber(parser: Runtime.INumber): string {
+  return `<Number>`
 }
 function FromOptional(parser: Runtime.IOptional): string {
   return `${FromParser(parser.parser)}?`
@@ -51,34 +54,35 @@ function FromOptional(parser: Runtime.IOptional): string {
 function FromRef(parser: Runtime.IRef): string {
   return `${parser.ref}`
 }
-function FromConst(parser: Runtime.IConst): string {
-  return `'${Escape(parser.value)}'`
+function FromString(parser: Runtime.IString): string {
+  return `<String>`
+}
+function FromTuple(parser: Runtime.ITuple): string {
+  return `[${parser.parsers.map((parser) => `${FromParser(parser)}`).join(', ')}]`
+}
+function FromUnion(parser: Runtime.IUnion): string {
+  return parser.parsers.map((parser) => `${FromParser(parser)}`).join(' | ')
 }
 function FromUntil(parser: Runtime.IUntil): string {
   return `string`
 }
-function FromIdent(parser: Runtime.IIdent): string {
-  return `<Ident>`
-}
-function FromString(parser: Runtime.IString): string {
-  return `<String>`
-}
-function FromNumber(parser: Runtime.INumber): string {
-  return `<Number>`
+function FromUntilNonEmpty(parser: Runtime.IUntilNonEmpty): string {
+  return `string`
 }
 function FromParser(parser: Runtime.IParser): string {
   return (
+    Runtime.IsArray(parser) ? FromArray(parser) : 
     Runtime.IsContext(parser) ? FromContext(parser) : 
+    Runtime.IsConst(parser) ? FromConst(parser) : 
+    Runtime.IsIdent(parser) ? FromIdent(parser) : 
+    Runtime.IsNumber(parser) ? FromNumber(parser) :
+    Runtime.IsOptional(parser) ? FromOptional(parser) : 
+    Runtime.IsRef(parser) ? FromRef(parser) : 
+    Runtime.IsString(parser) ? FromString(parser) : 
     Runtime.IsTuple(parser) ? FromTuple(parser) : 
     Runtime.IsUnion(parser) ? FromUnion(parser) : 
-    Runtime.IsArray(parser) ? FromArray(parser) : 
-    Runtime.IsOptional(parser) ? FromOptional(parser) : 
-    Runtime.IsString(parser) ? FromString(parser) : 
-    Runtime.IsConst(parser) ? FromConst(parser) : 
     Runtime.IsUntil(parser) ? FromUntil(parser) : 
-    Runtime.IsRef(parser) ? FromRef(parser) : 
-    Runtime.IsIdent(parser) ? FromIdent(parser) : 
-    Runtime.IsNumber(parser) ? FromNumber(parser) : 
+    Runtime.IsUntilNonEmpty(parser) ? FromUntilNonEmpty(parser) : 
     Unreachable(parser)
   )
 }

--- a/src/compile/common/infer.ts
+++ b/src/compile/common/infer.ts
@@ -32,40 +32,58 @@ THE SOFTWARE.
 import { Runtime } from '../../runtime/index.ts'
 import { Unreachable } from './unreachable.ts'
 
-function InferUnion(parsers: Runtime.IParser[]): string {
-  return [...new Set(parsers.map((parser) => Infer(parser)))].join(' | ')
-}
-function InferTuple(parsers: Runtime.IParser[]): string {
-  return `[${parsers.map(() => 'unknown').join(', ')}]`
-}
 function InferArray(parser: Runtime.IParser): string {
   return `(${Infer(parser)})[]`
 }
 function InferContext(left: Runtime.IParser, right: Runtime.IParser) {
   return Infer(right)
 }
+function InferConst(parser: Runtime.IConst) {
+  return `'${parser.value}'`
+}
 function InferOptional(parser: Runtime.IParser) {
   return `([${Infer(parser)}] | [])`
 }
-function InferConst(parser: Runtime.IConst) {
-  return `'${parser.value}'`
+
+
+function InferUnion(parsers: Runtime.IParser[]): string {
+  return [...new Set(parsers.map((parser) => Infer(parser)))].join(' | ')
+}
+function InferString(parser: Runtime.IString) {
+  return `string`
+}
+function InferRef(parser: Runtime.IRef) {
+  return `unknown`
+}
+function InferIdent(parser: Runtime.IIdent) {
+  return `string`
+}
+function InferNumber(parser: Runtime.INumber) {
+  return `string`
+}
+function InferTuple(parsers: Runtime.IParser[]): string {
+  return `[${parsers.map(() => 'unknown').join(', ')}]`
 }
 function InferUntil(parser: Runtime.IUntil) {
   return `string`
 }
+function InferUntilNonEmpty(parser: Runtime.IUntilNonEmpty) {
+  return `string`
+}
 export function Infer(parser: Runtime.IParser): string {
   return (
+    Runtime.IsArray(parser) ? InferArray(parser.parser) :
     Runtime.IsContext(parser) ? InferContext(parser.right, parser.right) :
+    Runtime.IsConst(parser) ? InferConst(parser) :
+    Runtime.IsIdent(parser) ? InferIdent(parser) :
+    Runtime.IsNumber(parser) ? InferNumber(parser) :
+    Runtime.IsOptional(parser) ? InferOptional(parser.parser) :
+    Runtime.IsRef(parser) ? InferRef(parser) :
+    Runtime.IsString(parser) ? InferString(parser) :
     Runtime.IsTuple(parser) ? InferTuple(parser.parsers) :
     Runtime.IsUnion(parser) ? InferUnion(parser.parsers) :
-    Runtime.IsArray(parser) ? InferArray(parser.parser) :
-    Runtime.IsOptional(parser) ? InferOptional(parser.parser) :
-    Runtime.IsRef(parser) ? `unknown` :
-    Runtime.IsConst(parser) ? InferConst(parser) :
     Runtime.IsUntil(parser) ? InferUntil(parser) :
-    Runtime.IsString(parser) ? `string` :
-    Runtime.IsIdent(parser) ? `string` :
-    Runtime.IsNumber(parser) ? `string` :
+    Runtime.IsUntilNonEmpty(parser) ? InferUntilNonEmpty(parser) :
     Unreachable(parser)
   )
 }

--- a/src/runtime/parse.ts
+++ b/src/runtime/parse.ts
@@ -129,6 +129,12 @@ function ParseUntil<Values extends string[]>(values: [...Values], code: string, 
   return Token.Until(values, code) as never
 }
 // ------------------------------------------------------------------
+// Until
+// ------------------------------------------------------------------
+function ParseUntilNonEmpty<Values extends string[]>(values: [...Values], code: string, context: unknown): [] | [string, string] {
+  return Token.UntilNonEmpty(values, code) as never
+}
+// ------------------------------------------------------------------
 // Parser
 // ------------------------------------------------------------------
 function ParseParser<Parser extends Types.IParser>(moduleProperties: Types.IModuleProperties, parser: Parser, code: string, context: unknown): [] | [Types.StaticParser<Parser>, string] {
@@ -144,6 +150,7 @@ function ParseParser<Parser extends Types.IParser>(moduleProperties: Types.IModu
     Types.IsTuple(parser) ? ParseTuple(moduleProperties, parser.parsers, code, context) :
     Types.IsUnion(parser) ? ParseUnion(moduleProperties, parser.parsers, code, context) :
     Types.IsUntil(parser) ?  ParseUntil(parser.values, code, context) :
+    Types.IsUntilNonEmpty(parser) ?  ParseUntilNonEmpty(parser.values, code, context) :
     []
   )
   return (result.length === 2 ? [parser.mapping(result[0], context), result[1]] : result) as never

--- a/src/runtime/token.ts
+++ b/src/runtime/token.ts
@@ -252,3 +252,14 @@ export function Until(value: string[], input: string, result: string = ''): [] |
     })()
   )
 }
+// ------------------------------------------------------------------
+// UntilNonEmpty
+// ------------------------------------------------------------------
+export function UntilNonEmpty(value: string[], input: string): [] | [string, string] {
+  const result = Until(value, input)
+  return (
+    result.length === 2
+      ? result[0].length === 0 ? []: result
+      : []
+  )
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -326,11 +326,11 @@ export interface IUntil<Output extends unknown = unknown> extends IParser<Output
   type: 'Until'
   values: string[]
 }
-/** `[TERM]` Creates a Until Parser */
+/** Creates a Until Parser */
 export function Until<Mapping extends IMapping<string>>(values: string[], mapping: Mapping): IUntil<string>
-/** `[TERM]` Creates a Until Parser */
+/** Creates a Until Parser */
 export function Until(values: string[]): IUntil<string>
-/** `[TERM]` Creates a Until Parser */
+/** Creates a Until Parser */
 export function Until(...args: unknown[]): never {
   const [values, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
   return { type: 'Until', values, mapping } as never
@@ -341,5 +341,29 @@ export function IsUntil(value: unknown): value is IUntil {
     && Guard.HasPropertyKey(value, 'type')
     && Guard.HasPropertyKey(value, 'values')
     && Guard.IsEqual(value.type, 'Until')
+    && Guard.IsArray(value.values)
+}
+// ------------------------------------------------------------------
+// UntilNonEmpty
+// ------------------------------------------------------------------
+export interface IUntilNonEmpty<Output extends unknown = unknown> extends IParser<Output> {
+  type: 'UntilNonEmpty'
+  values: string[]
+}
+/** Creates a UntilNonEmpty Parser */
+export function UntilNonEmpty<Mapping extends IMapping<string>>(values: string[], mapping: Mapping): IUntilNonEmpty<string>
+/** Creates a UntilNonEmpty Parser */
+export function UntilNonEmpty(values: string[]): IUntilNonEmpty<string>
+/** Creates a UntilNonEmpty Parser */
+export function UntilNonEmpty(...args: unknown[]): never {
+  const [values, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
+  return { type: 'Until1', values, mapping } as never
+}
+/** Returns true if the value is a UntilNonEmpty Parser */
+export function IsUntilNonEmpty(value: unknown): value is IUntilNonEmpty {
+  return Guard.IsObject(value)
+    && Guard.HasPropertyKey(value, 'type')
+    && Guard.HasPropertyKey(value, 'values')
+    && Guard.IsEqual(value.type, 'UntilNonEmpty')
     && Guard.IsArray(value.values)
 }

--- a/src/static/parse.ts
+++ b/src/static/parse.ts
@@ -116,6 +116,14 @@ type UntilParser<Values extends string[], Input extends string, _Context extends
     : []
 )
 // ------------------------------------------------------------------
+// UntilNonEmpty
+// ------------------------------------------------------------------
+type UntilNonEmptyParser<Values extends string[], Input extends string, _Context extends unknown> = (
+  Tokens.UntilNonEmpty<Values, Input> extends [infer Match extends string, infer Rest extends string]
+    ? [Match, Rest]
+    : []
+)
+// ------------------------------------------------------------------
 // Parse
 // ------------------------------------------------------------------
 type ParseCode<Parser extends Types.IParser, Input extends string, Context extends unknown = unknown> = (
@@ -129,6 +137,7 @@ type ParseCode<Parser extends Types.IParser, Input extends string, Context exten
   Parser extends Types.Tuple<infer Parsers extends Types.IParser[]> ? TupleParser<Parsers, Input, Context> :
   Parser extends Types.Union<infer Parsers extends Types.IParser[]> ? UnionParser<Parsers, Input, Context> :
   Parser extends Types.Until<infer Values extends string[]> ? UntilParser<Values, Input, Context> :
+  Parser extends Types.UntilNonEmpty<infer Values extends string[]> ? UntilNonEmptyParser<Values, Input, Context> :
   []
 )
 type ParseMapping<Parser extends Types.IParser, Result extends unknown, Context extends unknown = unknown> = (

--- a/src/static/token.ts
+++ b/src/static/token.ts
@@ -219,3 +219,11 @@ export type Until<Values extends string[], Input extends string, Result extends 
       ? Until<Values, Right, `${Result}${Left}`>
       : never
 )
+// ------------------------------------------------------------------
+// UntilNonEmpty
+// ------------------------------------------------------------------
+export type UntilNonEmpty<Values extends string[], Input extends string> = (
+  Until<Values, Input> extends [infer Left extends string, infer Right extends string]
+    ? Left extends '' ? [] : [Left, Right]
+    : []
+)

--- a/src/static/types.ts
+++ b/src/static/types.ts
@@ -85,14 +85,6 @@ export interface Const<Value extends string = string, Mapping extends IMapping =
   value: Value
 }
 // ------------------------------------------------------------------
-// Until
-// ------------------------------------------------------------------
-/** Creates a Until Parser */
-export interface Until<Values extends string[] = string[], Mapping extends IMapping = Identity> extends IParser<Mapping> {
-  type: 'Until'
-  values: Values
-}
-// ------------------------------------------------------------------
 // Ident
 // ------------------------------------------------------------------
 /** Creates an Ident Parser */
@@ -137,4 +129,20 @@ export interface Tuple<Parsers extends IParser[] = [], Mapping extends IMapping 
 export interface Union<Parsers extends IParser[] = [], Mapping extends IMapping = Identity> extends IParser<Mapping> {
   type: 'Union'
   parsers: [...Parsers]
+}
+// ------------------------------------------------------------------
+// Until
+// ------------------------------------------------------------------
+/** Creates a Until Parser */
+export interface Until<Values extends string[] = string[], Mapping extends IMapping = Identity> extends IParser<Mapping> {
+  type: 'Until'
+  values: Values
+}
+// ------------------------------------------------------------------
+// UntilNonEmpty
+// ------------------------------------------------------------------
+/** Creates a UntilNonEmpty Parser */
+export interface UntilNonEmpty<Values extends string[] = string[], Mapping extends IMapping = Identity> extends IParser<Mapping> {
+  type: 'UntilNonEmpty'
+  values: Values
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -34,7 +34,7 @@ Task.run('build', () => Task.build('src', {
   packageJson: {
     name: '@sinclair/parsebox',
     description: 'Parser Combinators in the TypeScript Type System',
-    version: '0.9.6',
+    version: '0.9.7',
     keywords: ['typescript', 'parser', 'combinator'],
     license: 'MIT',
     author: 'sinclairzx81',

--- a/test/__tests__/runtime/token.ts
+++ b/test/__tests__/runtime/token.ts
@@ -193,3 +193,114 @@ Deno.test('Until: Multi Sentinal Test', () => {
   Assert(Runtime.Token.Until(['B', ' A'], '   BA'), ['   ', 'BA'])
   Assert(Runtime.Token.Until([' B', 'A'], '   BA'), ['  ', ' BA'])
 })
+
+Deno.test('UntilNonEmpty: Empty', () => {
+  Assert(Runtime.Token.UntilNonEmpty([''], ''), [])
+  Assert(Runtime.Token.UntilNonEmpty([''], 'A'), [])
+  Assert(Runtime.Token.UntilNonEmpty([''], '   A'), [])
+})
+
+Deno.test('UntilNonEmpty: Single-Char', () => {
+  Assert(Runtime.Token.UntilNonEmpty(['A'], 'A'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], 'A '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], 'AA'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], 'AA '), [])
+})
+
+Deno.test('UntilNonEmpty: Multi-Char', () => {
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], 'AB'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], 'AB '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], 'ABA'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], 'ABA '), [])
+})
+
+Deno.test('UntilNonEmpty: Single-Char -> Ignore-Whitespace', () => {
+  Assert(Runtime.Token.UntilNonEmpty(['A'], '  A'), ['  ', 'A'])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], '  A '), ['  ', 'A '])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], '  AA'), ['  ', 'AA'])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], '  AA '), ['  ', 'AA '])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], '\nAA '), ['\n', 'AA '])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], ' \nAA '), [' \n', 'AA '])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], '\n AA '), ['\n ', 'AA '])
+  Assert(Runtime.Token.UntilNonEmpty(['A'], ' \n AA '), [' \n ', 'AA '])
+})
+
+Deno.test('UntilNonEmpty: Multi-Char -> Ignore-Whitespace', () => {
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], '  AB'), ['  ', 'AB'])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], '  AB '), ['  ', 'AB '])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], '  ABA'), ['  ', 'ABA'])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], '  ABA '), ['  ', 'ABA '])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], '\nABA '), ['\n', 'ABA '])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], ' \nABA '), [' \n', 'ABA '])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], '\n ABA '), ['\n ', 'ABA '])
+  Assert(Runtime.Token.UntilNonEmpty(['AB'], ' \n ABA '), [' \n ', 'ABA '])
+})
+
+Deno.test('UntilNonEmpty: Single-Whitespace', () => {
+  Assert(Runtime.Token.UntilNonEmpty([' '], ''), [])
+  Assert(Runtime.Token.UntilNonEmpty([' '], ' '), [])
+  Assert(Runtime.Token.UntilNonEmpty([' '], ' A'), [])
+  Assert(Runtime.Token.UntilNonEmpty([' '], ' A '), [])
+  Assert(Runtime.Token.UntilNonEmpty([' '], ' AA'), [])
+  Assert(Runtime.Token.UntilNonEmpty([' '], ' AA '), [])
+})
+
+Deno.test('UntilNonEmpty: Multi-Whitespace', () => {
+  Assert(Runtime.Token.UntilNonEmpty(['  '], ''), [])
+  Assert(Runtime.Token.UntilNonEmpty(['  '], ' '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['  '], '  A'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['  '], '  A '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['  '], '  AA'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['  '], '  AA '), [])
+})
+
+Deno.test('UntilNonEmpty: Newline', () => {
+  Assert(Runtime.Token.UntilNonEmpty(['\n'], ''), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n'], ' '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n'], '\nA'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n'], '  \nA '), ['  ', '\nA '])
+  Assert(Runtime.Token.UntilNonEmpty(['\n'], '  \nAA'), ['  ', '\nAA'])
+  Assert(Runtime.Token.UntilNonEmpty(['\n'], '  \nAA '), ['  ', '\nAA '])
+})
+
+Deno.test('UntilNonEmpty: Newline-Single-Whitespace', () => {
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], ''), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], ' '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], '\nA'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], '  \nA '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], '  \nAA'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], '  \nAA '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], '\n A'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], '  \n A '), ['  ', '\n A '])
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], '  \n AA'), ['  ', '\n AA'])
+  Assert(Runtime.Token.UntilNonEmpty(['\n '], '  \n AA '), ['  ', '\n AA '])
+})
+
+Deno.test('UntilNonEmpty: Newline-Multi-Whitespace', () => {
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], ''), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], ' '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], '\nA'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], '  \nA '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], '  \nAA'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], '  \nAA '), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], '\n  A'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], '  \n  A '), ['  ', '\n  A '])
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], '  \n  AA'), ['  ', '\n  AA'])
+  Assert(Runtime.Token.UntilNonEmpty(['\n  '], '  \n  AA '), ['  ', '\n  AA '])
+})
+
+Deno.test('UntilNonEmpty: Multi Sentinal Test', () => {
+  Assert(Runtime.Token.UntilNonEmpty(['A', 'B'], ''), [])
+  Assert(Runtime.Token.UntilNonEmpty(['A', 'B'], 'A'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['A', 'B'], 'B'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['A', 'B'], 'AB'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['A', 'B'], 'BA'), [])
+  Assert(Runtime.Token.UntilNonEmpty(['A', 'B'], '   AB'), ['   ', 'AB'])
+  Assert(Runtime.Token.UntilNonEmpty(['A', 'B'], '   BA'), ['   ', 'BA'])
+  Assert(Runtime.Token.UntilNonEmpty(['A', ' B'], '   BA'), ['  ', ' BA'])
+  Assert(Runtime.Token.UntilNonEmpty([' A', 'B'], '   BA'), ['   ', 'BA'])
+  Assert(Runtime.Token.UntilNonEmpty(['B', 'A'], '   AB'), ['   ', 'AB'])
+  Assert(Runtime.Token.UntilNonEmpty(['B', 'A'], '   BA'), ['   ', 'BA'])
+  Assert(Runtime.Token.UntilNonEmpty(['B', ' A'], '   BA'), ['   ', 'BA'])
+  Assert(Runtime.Token.UntilNonEmpty([' B', 'A'], '   BA'), ['  ', ' BA'])
+})

--- a/test/__tests__/static/token.ts
+++ b/test/__tests__/static/token.ts
@@ -229,3 +229,126 @@ Assert<Static.Token.Until<['B', 'A'], '   BA'>, ['   ', 'BA']>
 Assert<Static.Token.Until<['B', ' A'], '   BA'>, ['   ', 'BA']>
 Assert<Static.Token.Until<[' B', 'A'], '   BA'>, ['  ', ' BA']>
 
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Empty
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<[''], ''>, []>
+Assert<Static.Token.UntilNonEmpty<[''], 'A'>, []>
+Assert<Static.Token.UntilNonEmpty<[''], '   A'>, []>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Single-Char
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<['A'], 'A'>, []>
+Assert<Static.Token.UntilNonEmpty<['A'], 'A '>, []>
+Assert<Static.Token.UntilNonEmpty<['A'], 'AA'>, []>
+Assert<Static.Token.UntilNonEmpty<['A'], 'AA '>, []>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Multi-Char
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<['AB'], 'AB'>, []>
+Assert<Static.Token.UntilNonEmpty<['AB'], 'AB '>, []>
+Assert<Static.Token.UntilNonEmpty<['AB'], 'ABA'>, []>
+Assert<Static.Token.UntilNonEmpty<['AB'], 'ABA '>, []>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Single-Char -> Ignore-Whitespace
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<['A'], '  A'>, ['  ', 'A']>
+Assert<Static.Token.UntilNonEmpty<['A'], '  A '>, ['  ', 'A ']>
+Assert<Static.Token.UntilNonEmpty<['A'], '  AA'>, ['  ', 'AA']>
+Assert<Static.Token.UntilNonEmpty<['A'], '  AA '>, ['  ', 'AA ']>
+Assert<Static.Token.UntilNonEmpty<['A'], '\nAA '>, ['\n', 'AA ']>
+Assert<Static.Token.UntilNonEmpty<['A'], ' \nAA '>, [' \n', 'AA ']>
+Assert<Static.Token.UntilNonEmpty<['A'], '\n AA '>, ['\n ', 'AA ']>
+Assert<Static.Token.UntilNonEmpty<['A'], ' \n AA '>, [' \n ', 'AA ']>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Multi-Char -> Ignore-Whitespace
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<['AB'], '  AB'>, ['  ', 'AB']>
+Assert<Static.Token.UntilNonEmpty<['AB'], '  AB '>, ['  ', 'AB ']>
+Assert<Static.Token.UntilNonEmpty<['AB'], '  ABA'>, ['  ', 'ABA']>
+Assert<Static.Token.UntilNonEmpty<['AB'], '  ABA '>, ['  ', 'ABA ']>
+Assert<Static.Token.UntilNonEmpty<['AB'], '\nABA '>, ['\n', 'ABA ']>
+Assert<Static.Token.UntilNonEmpty<['AB'], ' \nABA '>, [' \n', 'ABA ']>
+Assert<Static.Token.UntilNonEmpty<['AB'], '\n ABA '>, ['\n ', 'ABA ']>
+Assert<Static.Token.UntilNonEmpty<['AB'], ' \n ABA '>, [' \n ', 'ABA ']>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Single-Whitespace
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<[' '], ''>, []>
+Assert<Static.Token.UntilNonEmpty<[' '], ' '>, []>
+Assert<Static.Token.UntilNonEmpty<[' '], ' A'>, []>
+Assert<Static.Token.UntilNonEmpty<[' '], ' A '>, []>
+Assert<Static.Token.UntilNonEmpty<[' '], ' AA'>, []>
+Assert<Static.Token.UntilNonEmpty<[' '], ' AA '>, []>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Multi-Whitespace
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<['  '], ''>, []>
+Assert<Static.Token.UntilNonEmpty<['  '], ' '>, []>
+Assert<Static.Token.UntilNonEmpty<['  '], '  A'>, []>
+Assert<Static.Token.UntilNonEmpty<['  '], '  A '>, []>
+Assert<Static.Token.UntilNonEmpty<['  '], '  AA'>, []>
+Assert<Static.Token.UntilNonEmpty<['  '], '  AA '>, []>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Newline
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<['\n'], ''>, []>
+Assert<Static.Token.UntilNonEmpty<['\n'], ' '>, []>
+Assert<Static.Token.UntilNonEmpty<['\n'], '\nA'>, []>
+Assert<Static.Token.UntilNonEmpty<['\n'], '  \nA '>, ['  ', '\nA ']>
+Assert<Static.Token.UntilNonEmpty<['\n'], '  \nAA'>, ['  ', '\nAA']>
+Assert<Static.Token.UntilNonEmpty<['\n'], '  \nAA '>, ['  ', '\nAA ']>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Newline-Single-Whitespace
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<['\n '], ''>, []>
+Assert<Static.Token.UntilNonEmpty<['\n '], ' '>, []>
+Assert<Static.Token.UntilNonEmpty<['\n '], '\nA'>, []>
+Assert<Static.Token.UntilNonEmpty<['\n '], '  \nA '>, []>
+Assert<Static.Token.UntilNonEmpty<['\n '], '  \nAA'>, []>
+Assert<Static.Token.UntilNonEmpty<['\n '], '  \nAA '>, []>
+Assert<Static.Token.UntilNonEmpty<['\n '], '\n A'>, []>
+Assert<Static.Token.UntilNonEmpty<['\n '], '  \n A '>, ['  ', '\n A ']>
+Assert<Static.Token.UntilNonEmpty<['\n '], '  \n AA'>, ['  ', '\n AA']>
+Assert<Static.Token.UntilNonEmpty<['\n '], '  \n AA '>, ['  ', '\n AA ']>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Newline-Multi-Whitespace
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<['\n  '], ''>, []>
+Assert<Static.Token.UntilNonEmpty<['\n  '], ' '>, []>
+Assert<Static.Token.UntilNonEmpty<['\n  '], '\nA'>, []>
+Assert<Static.Token.UntilNonEmpty<['\n  '], '  \nA '>, []>
+Assert<Static.Token.UntilNonEmpty<['\n  '], '  \nAA'>, []>
+Assert<Static.Token.UntilNonEmpty<['\n  '], '  \nAA '>, []>
+Assert<Static.Token.UntilNonEmpty<['\n  '], '\n  A'>, []>
+Assert<Static.Token.UntilNonEmpty<['\n  '], '  \n  A '>, ['  ', '\n  A ']>
+Assert<Static.Token.UntilNonEmpty<['\n  '], '  \n  AA'>, ['  ', '\n  AA']>
+Assert<Static.Token.UntilNonEmpty<['\n  '], '  \n  AA '>, ['  ', '\n  AA ']>
+
+// ------------------------------------------------------------------
+// UntilNonEmpty: Multi Sentinal Test
+// ------------------------------------------------------------------
+Assert<Static.Token.UntilNonEmpty<['A', 'B'], ''>, []>
+Assert<Static.Token.UntilNonEmpty<['A', 'B'], 'A'>, []>
+Assert<Static.Token.UntilNonEmpty<['A', 'B'], 'B'>, []>
+Assert<Static.Token.UntilNonEmpty<['A', 'B'], 'AB'>, []>
+Assert<Static.Token.UntilNonEmpty<['A', 'B'], 'BA'>, []>
+Assert<Static.Token.UntilNonEmpty<['A', 'B'], '   AB'>, ['   ', 'AB']>
+Assert<Static.Token.UntilNonEmpty<['A', 'B'], '   BA'>, ['   ', 'BA']>
+Assert<Static.Token.UntilNonEmpty<['A', ' B'], '   BA'>, ['  ', ' BA']>
+Assert<Static.Token.UntilNonEmpty<[' A', 'B'], '   BA'>, ['   ', 'BA']>
+Assert<Static.Token.UntilNonEmpty<['B', 'A'], '   AB'>, ['   ', 'AB']>
+Assert<Static.Token.UntilNonEmpty<['B', 'A'], '   BA'>, ['   ', 'BA']>
+Assert<Static.Token.UntilNonEmpty<['B', ' A'], '   BA'>, ['   ', 'BA']>
+Assert<Static.Token.UntilNonEmpty<[' B', 'A'], '   BA'>, ['  ', ' BA']>
+


### PR DESCRIPTION
This PR adds an additional Until combinator (UntilNonEmpty) which fails if the parser matches on a zero length string (indicating the sentinel was the next character). This is used to mirror (one or more) semantics, where the original Until combinator handled (zero or more).

This combinator is envisioned for use in recursive matching scenarios to mitigate stack overflow for non-consuming matches. It's noted that in the Until case, stack overflow was difficult to avoid when matches would succeed for zero captures (meaning the cursor never advances). This combinator aims to enable an alternative parsing strategy where parsing can terminate for zero length, with subsequent `Const` used to explicitly consume the sentinel.